### PR TITLE
Add a link to "delete all" events

### DIFF
--- a/themes/odyssey/stylesheets/_header.scss
+++ b/themes/odyssey/stylesheets/_header.scss
@@ -198,12 +198,20 @@ header {
   }
 
   &#events_subnav{
-    li > a{
+    li a, span {
+      color: white;
+    }
+
+    li >  a, span {
       display: block;
+    }
+
+    li > span > a {
+      text-decoration: underline;
     }
   }
 
-  li > a {
+  li  a, span {
     font-size: 0.85em;
     font-family: $font-family-fira-sans;
     color: #fff;

--- a/themes/odyssey/views/events/show.html.erb
+++ b/themes/odyssey/views/events/show.html.erb
@@ -25,10 +25,23 @@
           </li>
           <li><%= link_to 'Clone event', clone_event_url(@event) %>
           </li>
-          <li><%= link_to 'Delete event', event_url(@event), {
-              :method => :delete,
-              :confirm => "Are you sure you want to delete this event?"
-          } %>
+          <li>
+            <% if @event.rrule %>
+              <span>
+                Delete
+                <%= link_to 'this event', event_url(@event),
+                  method: :delete,
+                  confirm: "Are you sure you want to delete this event?" %>
+                or
+                <%= link_to 'all events', event_url(@event, delete_all: true),
+                  method: :delete,
+                  confirm: "Are you sure you want to delete all recurrences of this event?" %>
+              </span>
+            <% else %>
+              <%= link_to 'Delete event', event_url(@event),
+                    :method => :delete,
+                    :confirm => "Are you sure you want to delete this event?" %>
+            <% end %>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
I **think** we had this before, readding it after we moved the edit/delete buttons around.

![delete all](https://www.dropbox.com/s/q4ao1l7zutu4dni/Screenshot%202016-02-21%2010.24.52.png?dl=1)

If the event is not recurring, it just says "Delete Event".
