### PR TITLE
Fix week display

### DIFF
--- a/app/helpers/calendar_helper.rb
+++ b/app/helpers/calendar_helper.rb
@@ -42,7 +42,10 @@ module CalendarHelper
 
     def weeks
       first = date.beginning_of_week(START_DAY)
-      last = date.end_of_month.end_of_week(START_DAY)
+      last = [
+        date.end_of_month.end_of_week(START_DAY),
+        first.advance(weeks: 4).end_of_week(START_DAY)
+      ].max
       (first..last).to_a.in_groups_of(7)
     end
   end

--- a/app/helpers/calendar_helper.rb
+++ b/app/helpers/calendar_helper.rb
@@ -44,7 +44,7 @@ module CalendarHelper
       first = date.beginning_of_week(START_DAY)
       last = [
         date.end_of_month.end_of_week(START_DAY),
-        first.advance(weeks: 4).end_of_week(START_DAY)
+        first.advance(weeks: 3).end_of_week(START_DAY)
       ].max
       (first..last).to_a.in_groups_of(7)
     end

--- a/themes/odyssey/views/calendar/_index.html.erb
+++ b/themes/odyssey/views/calendar/_index.html.erb
@@ -3,19 +3,8 @@
 
 <div class='calendar'>
   <div class='month clearfix'>
-    <!-- How do you make RoR spit out a link without generating an a tag? -->
-    <% if !events_this_month?(@date.prev_month) %>
-      <%= link_to root_path(date: @date.prev_month.beginning_of_month), class: 'button prev' do %>
-        <i class='chevron chevron'></i> Prev Month
-      <% end %>
-    <% elsif Date.today.month == @date.prev_month.month %>
-      <%= link_to root_path(date: Date.today), class: 'button prev' do %>
-        <i class='chevron chevron'></i> Prev Month
-      <% end %>
-    <% else %>
-      <%= link_to root_path(date: @date.prev_month), class: 'button prev' do %>
-        <i class='chevron chevron'></i> Prev Month
-      <% end %>
+    <%= link_to root_path(date: @date.prev_month.beginning_of_month), class: 'button prev' do %>
+      <i class='chevron chevron'></i> Prev Month
     <% end %>
     <div class='month-name-container'>
       <span class='month-name'>
@@ -25,18 +14,8 @@
         <%= @date.strftime("%Y") %>
       </span>
     </div>
-    <% if !events_this_month?(@date.next_month) %>
-      <%= link_to root_path(date: @date.next_month.beginning_of_month), class: 'button next' do %>
-        Next Month <i class='chevron chevron--direction-right'></i>
-      <% end %>
-    <% elsif Date.today.month == @date.next_month.month %>
-      <%= link_to root_path(date: Date.today), class: 'button next' do %>
-        Next Month <i class='chevron chevron--direction-right'></i>
-      <% end %>
-    <% else %>
-      <%= link_to root_path(date: @date.next_month), class: 'button next' do %>
-        Next Month <i class='chevron chevron--direction-right'></i>
-      <% end %>
+    <%= link_to root_path(date: @date.next_month.beginning_of_month), class: 'button next' do %>
+      Next Month <i class='chevron chevron--direction-right'></i>
     <% end %>
   </div>
   <script>


### PR DESCRIPTION
Since we've started displaying the calendar starting with the current week, we have a slight regression. Towards the end of the month, we only show one week of activites.

![example](https://www.dropbox.com/s/h5udt47q22w9ms8/Screenshot%202016-03-30%2009.16.59.png?dl=1)

This now shows at least 4 weeks, no matter what day it is. It also ensures that when you click next month, you see that entire month.
